### PR TITLE
Clean up 'ready for review' label

### DIFF
--- a/dangerfile.prs.ts
+++ b/dangerfile.prs.ts
@@ -7,7 +7,7 @@ schedule(
     labels: {
       wip: 'WIP: Building',
       'needs testing': 'WIP: Needs Testing',
-      'ready for review': 'WIP: Ready for Review',
+      'ready for review': 'Ready for Review',
     },
   })
 );


### PR DESCRIPTION
Let's just simplify some of these - "WIP" being repeated on *every* PR tag is messy to read and not communicating anything more clearly than if it just said the thing without "WIP"